### PR TITLE
Improve spanish translation

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -21,7 +21,7 @@
   <string name="next">Siguiente</string>
   <string name="save">Guardar</string>
   <string name="custom">A medida</string>
-  <string name="training">Entreno</string>
+  <string name="training">Entrenamiento</string>
   <string name="bow">Arco</string>
   <string name="arrow">Flecha</string>
   <string name="round">Serie</string>
@@ -29,9 +29,9 @@
   <string name="passe">Tanda</string>
   <string name="passe_n">Tanda %d</string>
   <!-- Overview -->
-  <string name="new_training">Nuevo Entreno</string>
+  <string name="new_training">Nuevo Entrenamiento</string>
   <string name="new_bow">Nuevo Arco</string>
-  <string name="new_arrow">Nueva flecha</string>
+  <string name="new_arrow">Nueva Flecha</string>
   <string name="new_round">Nueva Serie</string>
   <plurals name="training_selected">
     <item quantity="one">Un Entrenamiento Seleccionado</item>
@@ -51,14 +51,14 @@
   </plurals>
   <string name="edit">Editar</string>
   <string name="delete">Borrar</string>
-  <string name="statistic">Estadisticas</string>
+  <string name="statistic">Estadísticas</string>
   <!-- Share -->
   <string name="share">Compartir</string>
   <string name="dispersion_pattern">Patrón de Dispersión</string>
-  <string name="sharing_failed">Fallo al Compartir!</string>
+  <string name="sharing_failed">¡Fallo al Compartir!</string>
   <!-- Export -->
   <string name="send_exported">Enviando Datos Exportados</string>
-  <string name="exporting_failed">Fallo en la Exportación!</string>
+  <string name="exporting_failed">¡Fallo en la Exportación!</string>
   <!-- New bow -->
   <string name="add_bow">Añade un Arco</string>
   <string name="name">Nombre</string>
@@ -82,7 +82,7 @@
   <string name="nock">Nock</string>
   <string name="material">Material</string>
   <!-- New round -->
-  <string name="title">Titulo</string>
+  <string name="title">Título</string>
   <string name="outdoor">Al aire libre</string>
   <string name="indoor">Interior</string>
   <string name="distance">Distancia</string>
@@ -97,7 +97,7 @@
     <item quantity="one">una Flecha</item>
     <item quantity="other">%d Flechas</item>
   </plurals>
-  <string name="target_face">Tamaño Objetivo</string>
+  <string name="target_face">Tamaño de Objetivo</string>
   <!-- Scoreboard -->
   <string name="scoreboard">Tablilla de Puntos</string>
   <string name="arrows">Flechas</string>
@@ -110,22 +110,22 @@
   <!-- Statistics -->
   <!-- Import/Backup -->
   <string name="select_a_file">Seleccciona un archivo</string>
-  <string name="dir_not_created">El directorio no puede ser creado!</string>
-  <string name="import_failed">Fallo en la Importación!</string>
-  <string name="file_not_found">Archivo no encontrado!</string>
-  <string name="failed_reading_file">Fallo leyendo el archivo!</string>
+  <string name="dir_not_created">¡El directorio no puede ser creado!</string>
+  <string name="import_failed">¡Fallo en la Importación!</string>
+  <string name="file_not_found">¡Archivo no encontrado!</string>
+  <string name="failed_reading_file">¡Fallo leyendo el archivo!</string>
   <!-- Donate -->
-  <string name="donate_2">Doname para una burger</string>
-  <string name="donate_5">Doname para un kebab</string>
-  <string name="donate_10">Doname para una Gran pizza</string>
-  <string name="donate_20">Doname para Gasolina</string>
-  <string name="donation_thank">Gracias por tu ayuda!</string>
+  <string name="donate_2">Dóname para una hamburguesa</string>
+  <string name="donate_5">Dóname para un kebab</string>
+  <string name="donate_10">Dóname para una pizza familiar</string>
+  <string name="donate_20">Dóname para gasolina</string>
+  <string name="donation_thank">¡Gracias por tu ayuda!</string>
   <string name="donate_text" formatted="false">Los impuestos están incluidos. IVA y el 30% de tasas para Google. Como alternativa, puedes gustosamente, donar en mi cuenta de PayPal (dreier.florian@gmail.com.)</string>
   <!-- Timer -->
   <string name="timer">Cronómetro</string>
   <string name="touch_to_start">Pulsa para empezar</string>
-  <string name="preparation">Preparación..</string>
-  <string name="shooting">Disparando..</string>
+  <string name="preparation">Preparación...</string>
+  <string name="shooting">Disparando...</string>
   <!-- Timer settings -->
   <string name="timer_shooting_time">Tiempo de Disparo</string>
   <string name="timer_waiting_time">Tiempo de Preparación</string>
@@ -149,7 +149,7 @@
   <string name="environment">Entorno</string>
   <string name="wind_speed">Velocidad del viento</string>
   <string name="wind_direction">Dirección del viento</string>
-  <string name="sight_setting_removed">Configuración de visor eliminada!</string>
+  <string name="sight_setting_removed">¡Configuración de visor eliminada!</string>
   <string name="metric">Métrico</string>
   <string name="imperial">Imperial</string>
   <string name="undo">Deshacer</string>
@@ -157,31 +157,31 @@
   <string name="expand_collapse">Expandir o contraer</string>
   <string name="new_round_template">Nueva plantilla</string>
   <string name="arrow_numbers">Números de flecha</string>
-  <string name="round_removed">Serie Eliminada!</string>
+  <string name="round_removed">¡Serie Eliminada!</string>
   <string name="custom_round">Serie Personalizada</string>
   <string name="filter">Filtro</string>
   <string name="club">Club</string>
   <string name="target">Blanco</string>
   <string name="standard_round">Serie Estandar</string>
   <string name="use_as_template">¿Utilizar como plantilla?</string>
-  <string name="create_copy">Esto es una Serie estándar! \nDo ¿desea crear una copia para poder editarlo?</string>
+  <string name="create_copy">Esto es una Serie Estándar! \n ¿Desea crear una copia para poder editarlo?</string>
   <string name="practice">Practicar</string>
-  <string name="edit_training">Editar Entreno</string>
-  <string name="edit_standard_round">Editar Serie Estandar</string>
+  <string name="edit_training">Editar Entrenamiento</string>
+  <string name="edit_standard_round">Editar Serie Estándar</string>
   <plurals name="arrow_deleted">
-    <item quantity="one">Una flecha eliminada</item>
+    <item quantity="one">Una Flecha eliminada</item>
     <item quantity="other">%d Flechas eliminadas</item>
   </plurals>
   <plurals name="bow_deleted">
-    <item quantity="one">Un arco eliminado</item>
-    <item quantity="other">%d arcos eliminados</item>
+    <item quantity="one">Un Arco eliminado</item>
+    <item quantity="other">%d Arcos eliminados</item>
   </plurals>
   <plurals name="training_deleted">
-    <item quantity="one">Uno entrenamiento eliminado</item>
+    <item quantity="one">Un Entrenamiento eliminado</item>
     <item quantity="other">%d Entrenamientos eliminados</item>
   </plurals>
   <plurals name="passe_deleted">
-    <item quantity="one">Una entrada Eliminada</item>
+    <item quantity="one">Una Entrada eliminada</item>
     <item quantity="other">%d Entradas eliminadas</item>
   </plurals>
   <plurals name="rounds">
@@ -190,11 +190,11 @@
   </plurals>
   <plurals name="round_selected">
     <item quantity="one">%d Series Seleccionadas</item>
-    <item quantity="other">%d tanda Seleccionada</item>
+    <item quantity="other">%d Series Seleccionada</item>
   </plurals>
   <plurals name="round_deleted">
     <item quantity="one">%d Series Seleccionadas</item>
-    <item quantity="other">%d series eliminadas</item>
+    <item quantity="other">%d Series eliminadas</item>
   </plurals>
   <string name="date">Fecha</string>
   <string name="edit_round">Editar Serie</string>
@@ -214,16 +214,16 @@
   <string name="stabilizer">Estabilizador</string>
   <string name="clicker">Clicker</string>
   <string name="arrow_number_x">%s número de flecha</string>
-  <string name="training_with_standard_round">Entreno Serie Estándar</string>
-  <string name="free_training">Entreno Libre</string>
+  <string name="training_with_standard_round">Entrenamiento Serie Estándar</string>
+  <string name="free_training">Entrenamiento Libre</string>
   <string name="competition">Competición</string>
   <string name="about">Acerca (Nº versión)</string>
   <string name="general">General</string>
   <string name="contribute">Contribuir</string>
   <string name="connect">Conectar</string>
   <string name="special_thanks_to">Agradecimientos especiales a</string>
-  <string name="all_translators">Todos los chicos, que ayudó a traducir la aplicación!</string>
-  <string name="all_beta_testers">Todos los que se unió al grupo de probadores beta y por lo tanto ayuda a mejorar continuamente la aplicación.</string>
+  <string name="all_translators">Toda la gente que ayuda a traducir la aplicación</string>
+  <string name="all_beta_testers">Todos los que se une al grupo de beta-testers y por lo tanto ayudan a mejorar continuamente la aplicación.</string>
   <string name="test_beta">Prueba la ultima versión Beta</string>
   <string name="join_on_google_plus">Únete a nosotros en Google+</string>
   <string name="share_with_friends">Comparte con tus amigos</string>
@@ -233,7 +233,7 @@
   <string name="network_linkedin">Red de LinkedIn</string>
   <string name="search">Búscar</string>
   <string name="us">Estados Unidos</string>
-  <string name="show_shots_training">Totalidad del entreno</string>
+  <string name="show_shots_training">Totalidad del entrenamiento</string>
   <string name="show_shots_round">Serie Actual</string>
   <string name="show_shots_end">Entrada Actual</string>
   <string name="profile">Perfil</string>
@@ -242,11 +242,11 @@
   <string name="last_name">Apellido(s)</string>
   <string name="age">Edad</string>
   <string name="show_signature">Firma</string>
-  <string name="witness">Witness</string>
+  <string name="witness">Testigo</string>
   <string name="archer">Arquero</string>
   <string name="hits">Aciertos</string>
   <string name="misses">Fallos</string>
-  <string name="new_end">Nuevo final</string>
+  <string name="new_end">Nuevo Final</string>
   <string name="distribution">Distribución</string>
   <string name="count">Cuenta</string>
   <string name="diameter">Diámetro</string>
@@ -260,7 +260,7 @@
   <string name="show_clusters">Agrupamiento</string>
   <string name="first_training_description">Pulse + para iniciar un nuevo entrenamiento.</string>
   <string name="show_average">Promedio</string>
-  <string name="show_none">Nignuno</string>
+  <string name="show_none">Ninguno</string>
   <string name="left_handed">Zurdos</string>
   <string name="right_handed">Diestros</string>
   <string name="keyboard">Teclado</string>
@@ -280,13 +280,13 @@
   <string name="delete_failed">Error al borrar</string>
   <string name="backup_restore_desc">Copiar y restaurar los datos de la aplicación</string>
   <string name="exporting">Exportando…</string>
-  <string name="loading_backups_failed">Error al cargar copias de seguridad!</string>
+  <string name="loading_backups_failed">¡Error al cargar copias de seguridad!</string>
   <string name="external_storage">Almacenamiento externo</string>
   <string name="backup_interval">Intervalo de copia de seguridad</string>
   <string name="daily">Diariamente</string>
   <string name="weekly">Semanalmente</string>
   <string name="monthly">Mensualmente</string>
-  <string name="connection_failed">Error de conexión!</string>
+  <string name="connection_failed">¡Error de conexión!</string>
   <string name="shooting_indoor">Tiro en Sala</string>
   <string name="bow_rest_vertical_position">Posición vertical</string>
   <string name="bow_rest">Descansar</string>
@@ -305,9 +305,9 @@
   <string name="intro_title_everything_in_one_place">Todo lo que necesitas \n en un lugar</string>
   <string name="intro_description_everything_in_one_place">Incluyendo arco - flecha-\nand sightmark-gestión, \narchery timer, estadísticas \nand mucho más…</string>
   <string name="average_arrow_score_per_end">Media de puntuaciones por entrada</string>
-  <string name="show_end">Ver entrada</string>
+  <string name="show_end">Ver Entrada</string>
   <string name="show_round">Ver Serie</string>
-  <string name="show_training">Ver entrenamiento</string>
+  <string name="show_training">Ver Entrenamiento</string>
   <string name="summary">Resúmen</string>
   <string name="end">Entrada</string>
   <string name="average_of">Promedio de</string>
@@ -323,6 +323,6 @@
   <string name="show_total_score">Mostrar puntuación total</string>
   <string name="show_percentage">Mostrar porcentajes</string>
   <string name="show_arrow_average">Mostrar media de flechas</string>
-  <string name="image_deleted">Image deleted</string>
-  <string name="delete_image">Delete image?</string>
+  <string name="image_deleted">Imagen borrada</string>
+  <string name="delete_image">¿Borrar imagen?</string>
 </resources>


### PR DESCRIPTION
A couple of typos, some improvements, including starting exclamation marks (¡) and capital letters for entities of the application (like `Flecha`, `Serie`, ...).