### PR TITLE
Fix Timer countdown rounding issue

### DIFF
--- a/app/src/main/java/de/dreier/mytargets/app/ApplicationInstance.kt
+++ b/app/src/main/java/de/dreier/mytargets/app/ApplicationInstance.kt
@@ -16,6 +16,7 @@
 package de.dreier.mytargets.app
 
 import android.arch.persistence.room.Room
+import android.arch.persistence.room.RoomDatabase
 import android.content.Context
 import android.content.SharedPreferences
 import android.content.res.Configuration

--- a/shared/src/main/java/de/dreier/mytargets/shared/base/fragment/TimerFragmentBase.kt
+++ b/shared/src/main/java/de/dreier/mytargets/shared/base/fragment/TimerFragmentBase.kt
@@ -107,10 +107,10 @@ abstract class TimerFragmentBase : Fragment(), View.OnClickListener {
                 applyTime("")
             } else {
                 val offset = getOffset(status)
-                countdown = object : CountDownTimer((getDuration(status) * 1000).toLong(), 100) {
+                countdown = object : CountDownTimer((getDuration(status) * 1000).toLong(), 1000) {
                     override fun onTick(millisUntilFinished: Long) {
-                        val text = (millisUntilFinished / 1000 + offset).toString()
-                        applyTime(text)
+                        val countdown = offset + Math.ceil(millisUntilFinished / 1000.0).toInt()
+                        applyTime(countdown.toString())
                     }
 
                     override fun onFinish() {


### PR DESCRIPTION
The timer does not match official timers, and there is a disturbing second left between the `0` and the `STOP`.

The actual sequence looks like:
9 -> ... -> 1 -> 0 -> 119 -> ... -> 1 -> 0 -> STOP

This PR change the sequence to:
10 -> ... -> 2 -> 1 -> 120 -> ... -> 2 -> 1 -> STOP